### PR TITLE
Add missing conditional to restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: "{{ filebeat_service_name }}"
     state: restarted
+  when: filebeat_service_status == 'started'


### PR DESCRIPTION
This fixes the issue when the service is being restarted even if the filebeat_service_status parameter is set to 'stopped'.