### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nephelaiio/ansible-role-filebeat/security/code-scanning/5](https://github.com/nephelaiio/ansible-role-filebeat/security/code-scanning/5)

To fix the issue, you should add a `permissions` key at the most appropriate scope (workflow root or job). In this case, the workflow has only one job, so you can safely add it either at the workflow (top) level or directly under the `lint` job. Following the principle of least privilege, set it to `contents: read`—the minimal recommended permission. No steps in this workflow require write access or any additional permissions.  
The edit should insert the block:
```yaml
permissions:
  contents: read
```
after the `name: lint` line (line 2), and before the `on:` block (line 4). This ensures that all jobs inherit the strictest permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
